### PR TITLE
Generate manifest.json

### DIFF
--- a/sitegenerator.py
+++ b/sitegenerator.py
@@ -7,11 +7,19 @@ from urllib.parse import urljoin
 import jinja2
 
 from portaldata import PortalData
+import util
 
 def writefile(filepath: Path, text: str):
 
     with io.open(filepath, 'w') as f:
         f.write(text)
+
+def make_manifest(vals: dict):
+
+    return [
+        { "id": id, "name": val.name }
+        for id, val in vals.items()
+    ]
 
 class PortalSite():
 
@@ -41,6 +49,8 @@ class PortalSite():
         self.generate_home()
         self.generate_tools()
         self.generate_orgs()
+
+        self.generate_manifest()
 
     def get_toolpath(self, tool_id):
         return PurePosixPath("tools") / tool_id
@@ -85,3 +95,18 @@ class PortalSite():
 
             os.makedirs(dir)
             writefile(filepath, template.render(site=self, org=org))
+
+    def generate_manifest(self):
+
+        manifest = {
+            "licenses": make_manifest(self.data.licenses),
+            "organizations": make_manifest(self.data.organizations),
+            "categories": make_manifest(self.data.categories),
+            "languages": make_manifest(self.data.languages),
+            "software": make_manifest(self.data.tools),
+        }
+
+        filepath = self.outpath / "manifest.json"
+
+        util.write_file(manifest, filepath)
+

--- a/util.py
+++ b/util.py
@@ -25,7 +25,7 @@ def write_file(data: Dict, file_path: Path) -> None:
 
     if file_path.suffix == ".json":
         with open(file_path, "w", encoding="utf-8") as file_pointer:
-            json.dump(data, file_pointer)
+            json.dump(data, file_pointer, indent=4)
         return
     raise NotImplementedError(
         f"Writing file of type {file_path.suffix} is not implemented."


### PR DESCRIPTION
Creates a JSON file in the site root to report the ids and names of all entities in the dataset, for use in opentools-form 