### PR TITLE
Fix Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,9 @@
-FROM python:3-slim AS builder
-ADD . /app 
-WORKDIR /app
+FROM python:3-slim
+COPY . /app
+RUN pip install pydantic jinja2
 
-# Installing dependency directly in 
-# the app directory
-RUN pip install --target=/app pydantic jinja2
-
-# Let's use a distroless container image for 
-# ptrhon and some basic SSL certificates
-# https://github.com/GoogleContainerTools/distroless
-
-FROM gcr.io/distroless/python3-debian12
-COPY --from=builder /app /app 
-# WORKDIR /app 
-ENV PYTHONPATH /app 
-CMD ["/app/main.py"]
+CMD python3 -u /app/main.py \
+    /github/workspace/$INPUT_DATAPATH \
+    /app/templates \
+    /github/workspace/$INPUT_SITEPATH \
+    $INPUT_BASEURL

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Installing dependency directly in 
 # the app directory
-RUN pip install --target=/app pydantic
+RUN pip install --target=/app pydantic jinja2
 
 # Let's use a distroless container image for 
 # ptrhon and some basic SSL certificates

--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,21 @@
-name: "GPST Opensource Tool Validator"
-description: "Use this validator to validate the data in GPST opentools repo"
-author: "Kapil Duwadi"
+name: "G-PST Open Tools Portal Builder"
+description: "Validates opentools source data and builds the portal website"
+author: "Kapil Duwadi and Gord Stephen"
+
 inputs:
   datapath:
-    description: "Path to data folder which is to be tested. By default assumes 'data' folder exists at the root of the repo."
-    required: false 
-outputs:
-  exitcode:
-    description: "Returns exit code after running pytest."
+    description: "Path to source data folder. Defaults to 'data'."
+    required: false
+    default: "data"
+  sitepath:
+    description: "Path to folder in which to generate site. Defaults to 'site'."
+    required: false
+    default: "site"
+  baseurl:
+    description: "URL prefix to be applied to links within the generated site."
+    required: false
+    default: "/"
+
 runs:
   using: docker
   image: "Dockerfile"

--- a/interface.py
+++ b/interface.py
@@ -35,8 +35,8 @@ class ToolCategory(BaseModel):
     """Interface for tree of software tool categorizations."""
 
     name: str
-    parent: Optional[str]
-    description: Optional[str]
+    parent: Optional[str] = None
+    description: Optional[str] = None
 
 
 class SoftwareTool(BaseModel):

--- a/main.py
+++ b/main.py
@@ -1,26 +1,29 @@
 """ Entry python module for github action. """
 
 # standard imports
-import os
+import sys
 
 from portaldata import PortalData
 from sitegenerator import PortalSite
 
-def main():
+def main(data_path: str, template_path: str, site_path: str, base_url: str):
     """Entry function for github action."""
-    try:
-        data_path = os.environ["INPUT_DATAPATH"]
-    except KeyError as _:
-        data_path = "data"
-        os.environ["INPUT_DATAPATH"] = data_path
 
-    print(f"Data for testing: {data_path}")
-
+    print(f"Loading data from: {data_path}")
     data = PortalData(data_path)
 
-    site = PortalSite(data)
-    site.generate(baseurl="", outpath="site")
+    print(f"Loading site templates from: {template_path}")
+    site = PortalSite(data, template_path)
+
+    print(f"Generating site in: {site_path}")
+    site.generate(baseurl=base_url, outpath=site_path)
 
 
 if __name__ == "__main__":
-    main()
+
+    data_path = sys.argv[1]
+    template_path = sys.argv[2]
+    site_path = sys.argv[3]
+    base_url = sys.argv[4]
+
+    main(data_path, template_path, site_path, base_url)

--- a/sitegenerator.py
+++ b/sitegenerator.py
@@ -23,12 +23,12 @@ def make_manifest(vals: dict):
 
 class PortalSite():
 
-    def __init__(self, data: PortalData):
+    def __init__(self, data: PortalData, template_path: str):
 
         self.data = data
 
         t_env = jinja2.Environment(
-                    loader=jinja2.FileSystemLoader("templates"),
+                    loader=jinja2.FileSystemLoader(template_path),
                     autoescape=jinja2.select_autoescape())
 
         self.templates = {


### PR DESCRIPTION
In GitHub Actions, the `WORKDIR` Docker parameter is always set to `/github/workspace`, which is synced to the contents of the checked out commit. This PR allows paths to the input data (in `/github/workspace`), the site templates (in `/app`), and output data (in `/github/workspace`) to be specified independently and explicitly provided to the Python script.

(baseurl is also added as an optional input parameter to the action, for cases where we need a base URL other than `/`)